### PR TITLE
Display the actual version of Zig used for compilation

### DIFF
--- a/hellos.zig
+++ b/hellos.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const builtin = @import("builtin");
 
 const MultiBoot = packed struct {
@@ -34,8 +35,10 @@ pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn
 }
 
 fn kmain() void {
+    const message = std.fmt.comptimePrint("Hello Kernel World from Zig {}!", .{builtin.zig_version});
+
     terminal.initialize();
-    terminal.write("Hello, Kernel World from Zig 0.7.1!");
+    terminal.write(message);
 }
 
 // Hardware text mode color constants


### PR DESCRIPTION
I found it weird that compiling this project using Zig 0.8.0-pre would still state "Hello, Kernel World from Zig 0.7.1!"

Of course, the way it's currently done could be intentional and just a way to indicate that it compiles with the most recent point-release. If that's the case, feel free to reject this PR.

Oh, and is there any reason why this project lacks a license? Does it have to do with how the original Bare Bones also lacked one?