### PR TITLE
Fix compiler errors - StackTrace and unused parameter.

### DIFF
--- a/hellos.zig
+++ b/hellos.zig
@@ -1,4 +1,4 @@
-const builtin = @import("builtin");
+const builtin = @import("std").builtin;
 
 const MultiBoot = packed struct {
     magic: i32,
@@ -27,6 +27,7 @@ export fn _start() callconv(.Naked) noreturn {
 }
 
 pub fn panic(msg: []const u8, error_return_trace: ?*builtin.StackTrace) noreturn {
+    _ = error_return_trace; // keep zig compiler happy with unused parameter
     @setCold(true);
     terminal.write("KERNEL PANIC: ");
     terminal.write(msg);


### PR DESCRIPTION
I can see a few PRs with the same fix. @andrewrk probably hasn't looked at this repo in a while.

Fixed minor compiling issues, due to changes in Zig compiler. `builtin.StackTrace` is now under `std`. Also Zig complains that `error_return_trace` is not being used. I toyed with doing some comptime checks of where StackTrace was located, but thought that the simpler changes were probably better. Also people are most probably using new versions of the Zig compiler anyway.

Tested on:
 `MacOS Big Sur 11.6.1 Intel`
```
% qemu-system-i386 -version
QEMU emulator version 6.1.0
```
```
% zig version
0.9.0-dev.1857+14b532ec8
```