### PR TITLE
Update for Zig v0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hellos
+hellos.o
 zig-cache

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bare bones "hello world" i386 kernel written in [Zig](https://ziglang.org/).
 ## Building
 
 ```
-zig build-exe hellos.zig -target i386-freestanding -T linker.ld
+zig build-exe hellos.zig -target x86-freestanding -T linker.ld -O ReleaseSmall
 ```
 
 ## Testing with qemu


### PR DESCRIPTION
This is what I believe are minimal changes to update this repo to work with the current version of Zig.

(It might be jumping the gun to update to v0.14 at this stage, but it's probably more useful than v0.7.)

Note that `-O ReleaseSmall` is required (although I think that `-O ReleaseFast` also works). Without this we get the following error:
```
error: Invalid record (Producer: 'zig 0.14.0' Reader: 'LLVM 19.1.4')
```